### PR TITLE
Fixed name issue with haproxy

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -591,28 +591,28 @@ object CheckCommand "haproxy_status" {
 
 	arguments = {
 		"--username" = {
-			value = "$haproxy_username$"
+			value = "$haproxy_status_username$"
 			description = "Username for HTTP Auth"
 		}
 		"--password" = {
-			value = "$haproxy_password$"
+			value = "$haproxy_status_password$"
 			description = "Password for HTTP Auth"
 		}
 		"--url" = {
-			value = "$haproxy_url$"
+			value = "$haproxy_status_url$"
 			description = "URL of the HAProxy csv statistics page"
 			required = true
 		}
 		"--timeout" = {
-			value = "$haproxy_timeout$"
+			value = "$haproxy_status_timeout$"
 			description = "Seconds before plugin times out (default: 10)"
 		}
 		"-w" = {
-			value = "$haproxy_warning$"
+			value = "$haproxy_status_warning$"
 			description = "Warning request time threshold (in seconds)"
 		}
 		"-c" = {
-			value = "$haproxy_critical$"
+			value = "$haproxy_status_critical$"
 			description = "Critical request time threshold (in seconds)"
 		}
 	}
@@ -624,39 +624,39 @@ object CheckCommand "haproxy" {
 
 	arguments = {
 		"--defaults" = {
-			value = "$haproxy_status_default$"
+			value = "$haproxy_default$"
 			description = "Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides)."
 		}
 		"--frontends" = {
-			set_if = "$haproxy_status_frontends$"
+			set_if = "$haproxy_frontends$"
 			description = "Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
 		}
 		"--nofrontends" = {
-			set_if = "$haproxy_status_nofrontends$"
+			set_if = "$haproxy_nofrontends$"
 			description = "Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
 		}
 		"--backends" = {
-			set_if = "$haproxy_status_backends$"
+			set_if = "$haproxy_backends$"
 			description = "Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
 		}
 		"--nobackends" = {
-			set_if = "$haproxy_status_nobackends$"
+			set_if = "$haproxy_nobackends$"
 			description = "Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
 		}
 		"--servers" = {
-			set_if = "$haproxy_status_servers$"
+			set_if = "$haproxy_servers$"
 			description = "Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
 		}
 		"--noservers" = {
-			set_if = "$haproxy_status_noservers$"
+			set_if = "$haproxy_noservers$"
 			description = "Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
 		}
 		"--overrides" = {
-			value = "$haproxy_status_overrides$"
+			value = "$haproxy_overrides$"
 			description = "Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above."
 		}
 		"--socket" = {
-			value = "$haproxy_status_socket$"
+			value = "$haproxy_socket$"
 			description = "Path to the socket check_haproxy should connect to"
 			required = true
 		}

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -585,7 +585,7 @@ object CheckCommand "varnish" {
 	}
 }
 
-object CheckCommand "haproxy" {
+object CheckCommand "haproxy_status" {
 	import "plugin-check-command"
 	command = [ PluginDir + "/check_haproxy" ]
 
@@ -618,9 +618,9 @@ object CheckCommand "haproxy" {
 	}
 }
 
-object CheckCommand "haproxy_status" {
+object CheckCommand "haproxy" {
 	import "plugin-check-command"
-	command = [ PluginDir + "/check_haproxy_status" ]
+	command = [ PluginDir + "/check_haproxy" ]
 
 	arguments = {
 		"--defaults" = {


### PR DESCRIPTION
haproxy is using the in build status page and haproxy_status is using the socket. So I'd like to propose the change of both like haproxy now is getting haproxy_status since it is using status page and haproxy_status now to haproxy since it is using the real socket for it.